### PR TITLE
Hotfix catchable fatal error when categories are deleted

### DIFF
--- a/includes/class-wcqu-post-type.php
+++ b/includes/class-wcqu-post-type.php
@@ -112,21 +112,21 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 		    case 'step':
 		        echo get_post_meta( $id, '_step', true );	       
 		        break;
-		        
-		    case 'cats':
-		   		$cats = get_post_meta( $id, '_cats', false);
-		   		if ( $cats != false and count( $cats[0] ) > 0 ) {	   		
-			   		foreach ( $cats[0] as $cat ){
-		
-			   			$taxonomy = 'product_cat'; 	
-				   		$term = get_term_by( 'id', $cat, $taxonomy );
-			   			$link = get_term_link( $term );	
-			   			
-			   			echo "<a href='" . $link . "'>" . $term->name . "</a><br />";	
-			   		}
-			   	} 
-		        break;  
-		        
+
+			case 'cats':
+				$cats = get_post_meta( $id, '_cats', false);
+				if ( $cats != false and count( $cats[0] ) > 0 ) {
+					foreach ( $cats[0] as $cat ) {
+
+						$taxonomy = 'product_cat';
+						$term = get_term_by( 'id', $cat, $taxonomy );
+						$link = get_term_link( $term );
+
+						echo "<a href='" . $link . "'>" . $term->name . "</a><br />";
+					}
+				}
+				break;
+
 		    case 'product_tags':
 		    	$tags = get_post_meta( $id, '_tags', false);
 		   		if ( $tags != null and count( $tags[0] ) > 0) {	   		

--- a/includes/class-wcqu-post-type.php
+++ b/includes/class-wcqu-post-type.php
@@ -122,6 +122,11 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 						$term = get_term_by( 'id', $cat, $taxonomy );
 						$link = get_term_link( $term );
 
+						if ( !$term || is_wp_error( $link ) ) {
+							echo "Unknown / Deleted Category<br />";
+							continue;
+						}
+
 						echo "<a href='" . $link . "'>" . $term->name . "</a><br />";
 					}
 				}

--- a/quantites-and-units.php
+++ b/quantites-and-units.php
@@ -3,7 +3,7 @@
 Plugin Name: Quantities and Units for WooCommerce
 Plugin URI: https://wordpress.org/plugins/quantities-and-units-for-woocommerce/
 Description: Easily require your customers to buy a minimum / maximum / incremental amount of products to continue with their checkout.
-Version: 1.0.13
+Version: 1.0.14
 Author: Nicholas Verwymeren
 Author URI: https://www.nickv.codes
 */ 

--- a/readme.txt
+++ b/readme.txt
@@ -70,6 +70,9 @@ Manual Installation
 6. Set Rules for categories by clicking the new ‘Quantity Rules’ sidebar option or assign per-product rules by using the new metabox on your product page.
 
 == Changelog ==
+= 1.0.14 =
+* Fixed an issue related to a category being deleted
+
 = 1.0.13 =
 * Fixed input issue introduced in 10.0.12 release
 


### PR DESCRIPTION
I noticed that when a category is deleted from the site that it was breaking the "Quantity Rules" page:

<img width="1425" alt="screen shot 2017-06-26 at 12 59 14 pm" src="https://user-images.githubusercontent.com/689046/27559449-7deb4142-5a75-11e7-9f46-64e93bcc4c2f.png">

This is a quick fix to instead just show some text that reads "Unknown / Deleted Category" in it's place:

<img width="1420" alt="screen shot 2017-06-26 at 12 59 58 pm" src="https://user-images.githubusercontent.com/689046/27559485-99e57b92-5a75-11e7-8ef7-f1e703ba7412.png">
