### PR TITLE
first pass WooCommerce 3.0 compatibility. 

### DIFF
--- a/includes/class-wcqu-actions.php
+++ b/includes/class-wcqu-actions.php
@@ -69,7 +69,7 @@ class WC_Quantities_and_Units_Actions {
 			return;
 		}
 		
-		if( $product->product_type == 'grouped' )
+		if( $product->is_type( 'grouped' ) )
 			return;
 		
 		$settings = get_option( 'ipq_options' );

--- a/includes/class-wcqu-filters.php
+++ b/includes/class-wcqu-filters.php
@@ -31,7 +31,7 @@ class WC_Quantities_and_Units_Filters {
 	 */
 	public function woocommerce_loop_add_to_cart_args( $args, $product ) {
 		// Return Defaults if it isn't a simple product 
-		if( $product->product_type != 'simple' ) {
+		if( ! $product->is_type( 'simple' ) ) {
 			return $args;
 		}
 
@@ -68,7 +68,7 @@ class WC_Quantities_and_Units_Filters {
 	public function input_min_value( $default, $product ) {
 
 		// Return Defaults if it isn't a simple product 
-		if( $product->product_type != 'simple' ) {
+		if( ! $product->is_type( 'simple' ) ) {
 			return $default;
 		}
 		
@@ -98,7 +98,7 @@ class WC_Quantities_and_Units_Filters {
 	public function input_max_value( $default, $product ) {	
 		
 		// Return Defaults if it isn't a simple product
-		if( $product->product_type != 'simple' ) {
+		if( ! $product->is_type( 'simple' ) ) {
 			return $default;
 		}
 		
@@ -128,7 +128,7 @@ class WC_Quantities_and_Units_Filters {
 	public function input_step_value( $default, $product ) {
 		
 		// Return Defaults if it isn't a simple product
-		if( $product->product_type != 'simple' ) {
+		if( ! $product->is_type( 'simple' ) ) {
 			return $default;
 		}
 		
@@ -160,7 +160,7 @@ class WC_Quantities_and_Units_Filters {
 		// Return Defaults if it isn't a simple product
 		/* Commented out to allow for grouped and variable products
 		*  on their product pages
-		if( $product->product_type != 'simple' ) {
+		if( ! $product->is_type( 'simple' ) ) {
 			return $args;
 		}
 		*/

--- a/includes/class-wcqu-product-meta-box.php
+++ b/includes/class-wcqu-product-meta-box.php
@@ -15,14 +15,14 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 	*	Register Rule Meta Box for Product Page for all but external products
 	*/
 	public function meta_box_create() {
-		global $post, $woocommerce;
+		global $post;
 
 		if ( $post->post_type == 'product' ) {
 			
-			$product = get_product( $post->ID );
+			$product = wc_get_product( $post->ID );
 			$unsupported_product_types = array( 'external', 'grouped' );
 
-			if ( ! in_array( $product->product_type, $unsupported_product_types ) ) {
+			if ( ! $product->is_type( $unsupported_product_types ) ) {
 						
 				add_meta_box(
 					'wpbo_product_info', 
@@ -41,7 +41,6 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 	*/
 	function product_meta_box_content( $post ) {
 		global $product;
-		global $woocommerce;
 		global $wp_roles;
 				
 		// Get the product and see what rules are being applied

--- a/includes/class-wcqu-product-unit.php
+++ b/includes/class-wcqu-product-unit.php
@@ -61,7 +61,7 @@ class WC_Quantities_and_Units_Product_Unit {
 	 */
 	public function get_price_suffix( $price_display_suffix, $product ) {
 		// todo make default unit configuarble
-		if ( $unit = $this->get_unit_for_product( $product->id, apply_filters( 'wciu_default_price_suffix', __( '', 'woocommerce' ) ) ) ) {
+		if ( $unit = $this->get_unit_for_product( $product->get_id(), apply_filters( 'wciu_default_price_suffix', __( '', 'woocommerce' ) ) ) ) {
 			$price_display_suffix = "/" . $unit . " " . $price_display_suffix;
 		}
 
@@ -77,7 +77,7 @@ class WC_Quantities_and_Units_Product_Unit {
 	 * @return  string
 	 */
 	public function sale_price_from_to( $price, $from, $to, $product ) {
-		if ( $unit = get_post_meta( $product->id, 'unit', true ) ) {
+		if ( $unit = get_post_meta( $product->get_id(), 'unit', true ) ) {
 			$price = '<del>' . ( ( is_numeric( $from ) ) ? wc_price( $from ) : $from ) . '/' . $unit . '</del> <ins>' . ( ( is_numeric( $to ) ) ? wc_price( $to ) : $to ) . '/' . $unit . '</ins>';
 		}
 
@@ -91,7 +91,7 @@ class WC_Quantities_and_Units_Product_Unit {
 	 * @return  string
 	 */
 	public function price_html( $html, $product ) {
-		$unit = get_post_meta( $product->id, 'unit', true );
+		$unit = get_post_meta( $product->get_id(), 'unit', true );
 		if ( $unit ) {
 			return $html . '/' . $unit;
 		}

--- a/includes/class-wcqu-units-box.php
+++ b/includes/class-wcqu-units-box.php
@@ -5,13 +5,13 @@ if ( ! class_exists( 'WC_Quantities_and_Units_Units_Box' ) ) :
 
 	class WC_Quantities_and_Units_Units_Box {
 		public function __construct() {
-			add_action( 'woocommerce_product_write_panels', array( $this, 'units_box_create' ) );
+			add_action( 'woocommerce_product_data_panels', array( $this, 'units_box_create' ) );
 			add_action( 'save_post', array( $this, 'save_unit_meta_data' ) );
 			add_action( 'woocommerce_product_write_panel_tabs', array($this, 'units_box_tab'), 99 );
 		}
 
 		function units_box_tab() {
-			echo '<li class="wciu_units_panel hide_if_grouped"><a href="#wciu_units_panel">Unit</a></li>';
+			echo '<li class="wciu_units_panel hide_if_grouped"><a href="#wciu_units_panel"><span>' . __( 'Unit', 'quantities-and-units' ). '</span></a></li>';
 		}
 
 		public function units_box_create() {

--- a/includes/wcqu-functions.php
+++ b/includes/wcqu-functions.php
@@ -13,10 +13,10 @@ function wcqu_get_applied_rule( $product, $role = null ) {
 	// Check for site wide rule
 	$options = get_option( 'ipq_options' );
 	
-	if ( get_post_meta( $product->id, '_wpbo_deactive', true ) == 'on' ) {
+	if ( get_post_meta( $product->get_id(), '_wpbo_deactive', true ) == 'on' ) {
 		return 'inactive';
 		
-	} elseif ( get_post_meta( $product->id, '_wpbo_override', true ) == 'on' ) {
+	} elseif ( get_post_meta( $product->get_id(), '_wpbo_override', true ) == 'on' ) {
 		return 'override';
 	
 	} elseif ( isset( $options['ipq_site_rule_active'] ) and $options['ipq_site_rule_active'] == 'on' ) {
@@ -38,8 +38,8 @@ function wcqu_get_applied_rule( $product, $role = null ) {
 function wcqu_get_applied_rule_obj( $product, $role = null ) {
 	
 	// Get Product Terms
-	$product_cats = wp_get_post_terms( $product->id, 'product_cat' );
-	$product_tags = wp_get_post_terms( $product->id, 'product_tag' );	
+	$product_cats = wp_get_post_terms( $product->get_id(), 'product_cat' );
+	$product_tags = wp_get_post_terms( $product->get_id(), 'product_tag' );	
 
 	// Get role if not passed
 	if(!is_user_logged_in()) {
@@ -178,13 +178,13 @@ function wcqu_get_value_from_rule( $type, $product, $rule ) {
 			// Return Out of Stock values if they exist
 			switch ( $type ) {
 				case 'min':
-					$min_oos = get_post_meta( $product->id, '_wpbo_minimum_oos', true );
+					$min_oos = get_post_meta( $product->get_id(), '_wpbo_minimum_oos', true );
 					if ( $min_oos != '' )
 						return $min_oos;
 					break;
 				
 				case 'max':
-					$max_oos = get_post_meta( $product->id, '_wpbo_maximum_oos', true );
+					$max_oos = get_post_meta( $product->get_id(), '_wpbo_maximum_oos', true );
 					if ( $max_oos != '' )
 						return $max_oos;
 					break;	
@@ -195,31 +195,31 @@ function wcqu_get_value_from_rule( $type, $product, $rule ) {
 		switch ( $type ) {
 			case 'all':
 				return array( 
-						'min_value' => get_post_meta( $product->id, '_wpbo_minimum', true ),
-						'max_value' => get_post_meta( $product->id, '_wpbo_maximum', true ),
-						'step' 		=> get_post_meta( $product->id, '_wpbo_step', true ),
-						'min_oos'	=> get_post_meta( $product->id, '_wpbo_minimum_oos', true ),
-						'max_oos'	=> get_post_meta( $product->id, '_wpbo_maximum_oos', true ),
+						'min_value' => get_post_meta( $product->get_id(), '_wpbo_minimum', true ),
+						'max_value' => get_post_meta( $product->get_id(), '_wpbo_maximum', true ),
+						'step' 		=> get_post_meta( $product->get_id(), '_wpbo_step', true ),
+						'min_oos'	=> get_post_meta( $product->get_id(), '_wpbo_minimum_oos', true ),
+						'max_oos'	=> get_post_meta( $product->get_id(), '_wpbo_maximum_oos', true ),
 					);
 				break;
 			case 'min':
-				return get_post_meta( $product->id, '_wpbo_minimum', true );
+				return get_post_meta( $product->get_id(), '_wpbo_minimum', true );
 				break;
 			
 			case 'max': 
-				return get_post_meta( $product->id, '_wpbo_maximum', true );
+				return get_post_meta( $product->get_id(), '_wpbo_maximum', true );
 				break;
 				
 			case 'step':
-				return get_post_meta( $product->id, '_wpbo_step', true );
+				return get_post_meta( $product->get_id(), '_wpbo_step', true );
 				break;
 			
 			case 'min_oos':
-				return get_post_meta( $product->id, '_wpbo_minimum_oos', true );
+				return get_post_meta( $product->get_id(), '_wpbo_minimum_oos', true );
 				break;
 			
 			case 'max_oos':
-				return get_post_meta( $product->id, '_wpbo_maximum_oos', true );
+				return get_post_meta( $product->get_id(), '_wpbo_maximum_oos', true );
 				break;
 				
 			case 'priority':

--- a/quantites-and-units.php
+++ b/quantites-and-units.php
@@ -6,6 +6,8 @@ Description: Easily require your customers to buy a minimum / maximum / incremen
 Version: 1.0.13
 Author: Nicholas Verwymeren
 Author URI: https://www.nickv.codes
+WC requires at least: 3.0.0    
+WC tested up to: 3.2.0  
 */ 
 
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
@@ -196,10 +198,10 @@ class WC_Quantities_and_Units {
 			if ( ! is_cart() ) {
 				
 				// Get the product
-				$pro = get_product( $post );
+				$pro = wc_get_product( $post );
 				
 				// Check if variable
-				if ( $pro->product_type == 'variable' ) {
+				if ( $pro->is_type( 'variable' ) ) {
 
 					// See what rules are being applied
 					$rule_result = wcqu_get_applied_rule( $pro );


### PR DESCRIPTION
Notes:
1. back-compatibility with pre-3.0 is not preserved. To preserve it you would need to write a helper function that always checks the WooCommerce version number and returns `$product->id` or `$product->get_id()` as appropriate. 
2. product data is not saved via CRUD. But `get_post_meta()` and `update_post_meta()` are still viable. 