### PR TITLE
Proposal for Plugin Handover & PHP8 Compatibility Update

### DIFF
--- a/includes/class-wcqu-actions.php
+++ b/includes/class-wcqu-actions.php
@@ -10,7 +10,7 @@ class WC_Quantities_and_Units_Actions {
 		// Conditionally add quantity note to product page
 		$settings = get_option( 'ipq_options' );
 
-		if ( isset( $settings['ipq_show_qty_note'] ) and $settings['ipq_show_qty_note'] == 'on' ) {
+		if ( isset( $settings['ipq_show_qty_note'] ) and $settings['ipq_show_qty_note'] === 'on' ) {
 			add_action( 'init', array( $this, 'apply_product_notification' ) );
 		}
 		
@@ -31,7 +31,7 @@ class WC_Quantities_and_Units_Actions {
 		$settings = get_option( 'ipq_options' );
 		extract( $settings );
 		
-		if ( isset( $ipq_show_qty_note ) and $ipq_show_qty_note == 'on' ) {
+		if ( isset( $ipq_show_qty_note ) and $ipq_show_qty_note === 'on' ) {
 			
 			// Get add_to_cart action priority
 			global $wp_filter;
@@ -40,10 +40,10 @@ class WC_Quantities_and_Units_Actions {
 			$cart_priority = has_filter( $action_to_check, $target_function );
 			
 			// Set the priory level based on add to cart
-			if ( $cart_priority == null ) {
+			if ( empty($cart_priority) ) {
 				$priority = 30;
 				
-			} elseif ( isset( $ipq_show_qty_note_pos ) and $ipq_show_qty_note_pos == 'below' ) {
+			} elseif ( isset( $ipq_show_qty_note_pos ) and $ipq_show_qty_note_pos === 'below' ) {
 				$priority = $cart_priority + 1;
 												
 			} else {
@@ -69,7 +69,7 @@ class WC_Quantities_and_Units_Actions {
 			return;
 		}
 		
-		if( $product->product_type == 'grouped' )
+		if( $product->product_type === 'grouped' )
 			return;
 		
 		$settings = get_option( 'ipq_options' );
@@ -79,7 +79,7 @@ class WC_Quantities_and_Units_Actions {
 		$rule = wcqu_get_applied_rule( $product );
 		
 		// Return nothing if APQ is deactivated
-		if ( $rule == 'inactive' or $rule == null ) {
+		if ( $rule === 'inactive' or empty($rule) ) {
 			return; 
 		}
 		
@@ -87,7 +87,7 @@ class WC_Quantities_and_Units_Actions {
 		$stock = $product->get_stock_quantity();
 
 		// Check if the product is under stock management and out of stock
-		if ( strlen( $stock ) != 0 and $stock <= 0 ) {
+		if ( strlen( $stock ) !== 0 and $stock <= 0 ) {
 			$min = wcqu_get_value_from_rule( 'min_oos', $product, $rule );
 			$max = wcqu_get_value_from_rule( 'max_oos', $product, $rule );
 		} else {
@@ -98,7 +98,7 @@ class WC_Quantities_and_Units_Actions {
 		$step = wcqu_get_value_from_rule( 'step', $product, $rule );
 
 		// If sitewide rule is applied, convert return arrays to values
-		if ( $rule == 'sitewide' and strlen( $stock ) != 0 and $stock <= 0  ) {
+		if ( $rule === 'sitewide' and strlen( $stock ) !== 0 and $stock <= 0  ) {
 			if ( is_array( $min ) )
 				$min = $min['min_oos'];
 		
@@ -108,7 +108,7 @@ class WC_Quantities_and_Units_Actions {
 			if ( is_array( $step ) ) {
 				$step = $step['step'];
 			}
-		} else if ( $rule == 'sitewide' ) {
+		} else if ( $rule === 'sitewide' ) {
 			if ( is_array( $min ) )
 				$min = $min['min'];
 		
@@ -132,7 +132,7 @@ class WC_Quantities_and_Units_Actions {
 
 			// Output result with optional custom class
 			echo "<span";
-			if ( isset( $ipq_qty_class ) and $ipq_qty_class != '' )
+			if ( isset( $ipq_qty_class ) and !empty($ipq_qty_class) )
 				echo " class='" . $ipq_qty_class . "'";
 			echo ">";	
 			echo $ipq_qty_text;

--- a/includes/class-wcqu-advanced-rules.php
+++ b/includes/class-wcqu-advanced-rules.php
@@ -35,7 +35,7 @@ class WC_Quantities_and_Units_Advanced_Rules {
 	*/
 	public function page_loaded() {
 		
-		if ( isset( $_POST["ipq-advanced-rules-submit"] ) and $_POST["ipq-advanced-rules-submit"] == 'Y' ) {
+		if ( isset( $_POST["ipq-advanced-rules-submit"] ) and $_POST["ipq-advanced-rules-submit"] === 'Y' ) {
 			
 			check_admin_referer( "ipq-advanced-rules" );
 			$this->save_settings();
@@ -54,21 +54,21 @@ class WC_Quantities_and_Units_Advanced_Rules {
 		$settings = get_option( 'ipq_options' );
 		
 		// Minimum Product Notification 
-		if ( isset( $_POST['ipq_show_qty_note'] ) and $_POST['ipq_show_qty_note'] == 'on' ) {
+		if ( isset( $_POST['ipq_show_qty_note'] ) and $_POST['ipq_show_qty_note'] === 'on' ) {
 			$settings['ipq_show_qty_note'] = 'on';
 		} else {
 			$settings['ipq_show_qty_note'] = '';
 		}
 		
 		// Minimum Note Text 
-		if ( isset( $_POST['ipq_qty_text'] ) and $_POST['ipq_qty_text'] != '' ) {
+		if ( isset( $_POST['ipq_qty_text'] ) and !empty($_POST['ipq_qty_text']) ) {
 			$settings['ipq_qty_text'] = stripslashes( $_POST['ipq_qty_text'] );
 		} else {
 			$settings['ipq_qty_text'] = '';
 		}
 		
 		// Minimum Note Position
-		if ( isset( $_POST['ipq_show_qty_note_pos'] ) and $_POST['ipq_show_qty_note_pos'] == 'below' ) {
+		if ( isset( $_POST['ipq_show_qty_note_pos'] ) and $_POST['ipq_show_qty_note_pos'] === 'below' ) {
 			$settings['ipq_show_qty_note_pos'] = 'below';
 		} else {
 			$settings['ipq_show_qty_note_pos'] = 'above';
@@ -80,7 +80,7 @@ class WC_Quantities_and_Units_Advanced_Rules {
 		} 
 		
 		// Active Rule
-		if ( isset( $_POST['ipq_site_rule_active'] ) and $_POST['ipq_site_rule_active'] == 'on' ) {
+		if ( isset( $_POST['ipq_site_rule_active'] ) and $_POST['ipq_site_rule_active'] === 'on' ) {
 			$settings['ipq_site_rule_active'] = 'on';
 		} else {
 			$settings['ipq_site_rule_active'] = '';
@@ -115,19 +115,19 @@ class WC_Quantities_and_Units_Advanced_Rules {
 		
 		// Make sure min <= max
 		if ( isset( $step ) and isset( $max ) ) {
-			if ( $min > $max and $max != '' and $max != 0 ) {
+			if ( $min > $max and !empty($max) ) {
 				$max = $min;
 			}
 		}
 		
 		// Make sure min_oos <= max and max_oos
-		if ( isset( $min_oos ) and $min_oos != 0 ) {
-			if ( isset( $max_oos ) and $max_oos != 0 and
+		if ( isset( $min_oos ) and !empty($min_oos) ) {
+			if ( isset( $max_oos ) and !empty($max_oos) and
 				$min_oos > $max_oos ) {
 
 				$max_oos = $min_oos;
 			} else if ( !isset( $max_oos ) and isset ( $max ) and
-				$max != 0 and $min_oos > $max ) {
+				!empty($max) and $min_oos > $max ) {
 				$min_oos = $max;
 			}
 		}
@@ -169,7 +169,7 @@ class WC_Quantities_and_Units_Advanced_Rules {
 		
 		$options = get_option( 'ipq_options' );
 
-		if ($options == false) {
+		if (empty($options)) {
 			$options = array();
 		}
 
@@ -185,44 +185,44 @@ class WC_Quantities_and_Units_Advanced_Rules {
 				<tr>
 					<th>Activate Site Wide Rules?</th>
 					<td><input type='checkbox' name='ipq_site_rule_active' id='ipq_site_rule_active'
-						<?php if ( isset( $ipq_site_rule_active ) and $ipq_site_rule_active != '' ) echo 'checked'; ?>
+						<?php if ( isset( $ipq_site_rule_active ) and !empty($ipq_site_rule_active) ) echo 'checked'; ?>
 					 /></td>
 				</tr>
 
-				<?php if ( isset( $ipq_site_rule_active ) and $ipq_site_rule_active != '' ): ?>
+				<?php if ( isset( $ipq_site_rule_active ) and !empty($ipq_site_rule_active) ): ?>
 				
 					<tr>
 						<th>Site Wide Product Minimum</th>
 						<td><input type='number' name='ipq_site_min' id='ipq_site_min'
-							value='<?php if ( isset( $ipq_site_min ) and $ipq_site_min != '' ) echo $ipq_site_min; ?>' step="any"
+							value='<?php if ( isset( $ipq_site_min ) and !empty($ipq_site_min) ) echo $ipq_site_min; ?>' step="any"
 						 /></td>
 					</tr>
 					
 					<tr>
 						<th>Site Wide Product Maximum</th>
 						<td><input type='number' name='ipq_site_max' id='ipq_site_max'
-							value='<?php if ( isset( $ipq_site_max ) and $ipq_site_max != '' ) echo $ipq_site_max; ?>' step="any"
+							value='<?php if ( isset( $ipq_site_max ) and !empty($ipq_site_max) ) echo $ipq_site_max; ?>' step="any"
 						 /></td>
 					</tr>
 					
 					<tr>
 						<th>Site Wide Product Minimum Out of Stock</th>
 						<td><input type='number' name='ipq_site_min_oos' id='ipq_site_min_oos'
-							value='<?php if ( isset( $ipq_site_min_oos ) and $ipq_site_min_oos != '' ) echo $ipq_site_min_oos; ?>' step="any"
+							value='<?php if ( isset( $ipq_site_min_oos ) and !empty($ipq_site_min_oos) ) echo $ipq_site_min_oos; ?>' step="any"
 						 /></td>
 					</tr>
 					
 					<tr>
 						<th>Site Wide Product Maximum Out of Stock</th>
 						<td><input type='number' name='ipq_site_max_oos' id='ipq_site_max_oos'
-							value='<?php if ( isset( $ipq_site_max_oos ) and $ipq_site_max_oos != '' ) echo $ipq_site_max_oos; ?>' step="any"
+							value='<?php if ( isset( $ipq_site_max_oos ) and !empty($ipq_site_max_oos) ) echo $ipq_site_max_oos; ?>' step="any"
 						 /></td>
 					</tr>
 					
 					<tr>
 						<th>Site Wide Step Value</th>
 						<td><input type='number' step='any' name='ipq_site_step' id='ipq_site_step'
-							value='<?php if ( isset( $ipq_site_step ) and $ipq_site_step != '' ) echo $ipq_site_step; ?>' step="any"
+							value='<?php if ( isset( $ipq_site_step ) and !empty($ipq_site_step) ) echo $ipq_site_step; ?>' step="any"
 						 /></td>
 					</tr>
 					
@@ -238,7 +238,7 @@ class WC_Quantities_and_Units_Advanced_Rules {
 				<tr>
 					<th>Show Quantity Notification on Product Page?</th>
 					<td><input type='checkbox' name='ipq_show_qty_note' id='ipq_show_qty_note' 
-						<?php if ( isset( $ipq_show_qty_note ) and $ipq_show_qty_note != '' ) echo 'checked'; ?>
+						<?php if ( isset( $ipq_show_qty_note ) and !empty($ipq_show_qty_note) ) echo 'checked'; ?>
 						/></td>
 				</tr>
 				
@@ -246,8 +246,8 @@ class WC_Quantities_and_Units_Advanced_Rules {
 					<th>Notification Position</th>
 					<td>
 						<select name='ipq_show_qty_note_pos' id='ipq_show_qty_note_pos'>
-							<option value='above' <?php if ( isset( $ipq_show_qty_note_pos ) and $ipq_show_qty_note_pos == 'above' ) echo 'selected' ?>>Above Add To Cart</option>
-							<option value='below' <?php if ( isset( $ipq_show_qty_note_pos ) and  $ipq_show_qty_note_pos == 'below' ) echo 'selected' ?>>Below Add To Cart</option>
+							<option value='above' <?php if ( isset( $ipq_show_qty_note_pos ) and $ipq_show_qty_note_pos === 'above' ) echo 'selected' ?>>Above Add To Cart</option>
+							<option value='below' <?php if ( isset( $ipq_show_qty_note_pos ) and  $ipq_show_qty_note_pos === 'below' ) echo 'selected' ?>>Below Add To Cart</option>
 						</select>
 					</td>
 				</tr>
@@ -255,7 +255,7 @@ class WC_Quantities_and_Units_Advanced_Rules {
 				<tr>
 					<th>Quantity Notification Text</th>
 					<td><input type='text' name='ipq_qty_text' id='ipq_qty_text' value='<?php 
-							if ( isset( $ipq_qty_text ) and $ipq_qty_text != '' ) {
+							if ( isset( $ipq_qty_text ) and !empty($ipq_qty_text) ) {
 								echo $ipq_qty_text; 
 							} else {
 								echo $qty_text_default;	
@@ -272,7 +272,7 @@ class WC_Quantities_and_Units_Advanced_Rules {
 				</tr>
 				<tr>
 					<th>Custom Quantity Note HTML Class</th>
-					<td><input type='text' name='ipq_qty_class' id='ipq_qty_class' value='<?php if ( isset( $ipq_qty_class ) and $ipq_qty_class != '' ) echo $ipq_qty_class; ?>' /></td>
+					<td><input type='text' name='ipq_qty_class' id='ipq_qty_class' value='<?php if ( isset( $ipq_qty_class ) and !empty($ipq_qty_class) ) echo $ipq_qty_class; ?>' /></td>
 				</tr>
 				
 				<tr>

--- a/includes/class-wcqu-filters.php
+++ b/includes/class-wcqu-filters.php
@@ -31,7 +31,7 @@ class WC_Quantities_and_Units_Filters {
 	 */
 	public function woocommerce_loop_add_to_cart_args( $args, $product ) {
 		// Return Defaults if it isn't a simple product 
-		if( $product->product_type != 'simple' ) {
+		if( $product->product_type !== 'simple' ) {
 			return $args;
 		}
 
@@ -68,7 +68,7 @@ class WC_Quantities_and_Units_Filters {
 	public function input_min_value( $default, $product ) {
 
 		// Return Defaults if it isn't a simple product 
-		if( $product->product_type != 'simple' ) {
+		if( $product->product_type !== 'simple' ) {
 			return $default;
 		}
 		
@@ -79,7 +79,7 @@ class WC_Quantities_and_Units_Filters {
 		$min = wcqu_get_value_from_rule( 'min', $product, $rule );
 		
 		// Return Value
-		if ( $min == '' or $min == null or (isset($min['min']) and $min['min'] == "")) {
+		if ( empty($min) or (isset($min['min']) and empty($min['min']))) {
 			return $default;
 		} else {
 			return $min;
@@ -98,7 +98,7 @@ class WC_Quantities_and_Units_Filters {
 	public function input_max_value( $default, $product ) {	
 		
 		// Return Defaults if it isn't a simple product
-		if( $product->product_type != 'simple' ) {
+		if( $product->product_type !== 'simple' ) {
 			return $default;
 		}
 		
@@ -109,7 +109,7 @@ class WC_Quantities_and_Units_Filters {
 		$max = wcqu_get_value_from_rule( 'max', $product, $rule );
 	
 		// Return Value
-		if ( $max == '' or $max == null or (isset($max['max']) and $max['max'] == "")) {
+		if ( empty($max) or (isset($max['max']) and empty($max['max']))) {
 			return $default;
 		} else {
 			return $max;
@@ -128,7 +128,7 @@ class WC_Quantities_and_Units_Filters {
 	public function input_step_value( $default, $product ) {
 		
 		// Return Defaults if it isn't a simple product
-		if( $product->product_type != 'simple' ) {
+		if( $product->product_type !== 'simple' ) {
 			return $default;
 		}
 		
@@ -139,7 +139,7 @@ class WC_Quantities_and_Units_Filters {
 		$step = wcqu_get_value_from_rule( 'step', $product, $rule );
 	
 		// Return Value
-		if ( $step == '' or $step == null or (isset($step['step']) and $step['step'] == "")) {
+		if ( empty($step) or (isset($step['step']) and empty($step['step']))) {
 			return $default;
 		} else {
 			return isset($step['step']) ? $step['step'] : $step;
@@ -160,7 +160,7 @@ class WC_Quantities_and_Units_Filters {
 		// Return Defaults if it isn't a simple product
 		/* Commented out to allow for grouped and variable products
 		*  on their product pages
-		if( $product->product_type != 'simple' ) {
+		if( $product->product_type !== 'simple' ) {
 			return $args;
 		}
 		*/
@@ -171,7 +171,7 @@ class WC_Quantities_and_Units_Filters {
 		// Get Value from Rule
 		$values = wcqu_get_value_from_rule( 'all', $product, $rule );
 
-		if ( $values == null ) {
+		if ( empty($values) ) {
 			return $args;
 		}
 		
@@ -182,29 +182,29 @@ class WC_Quantities_and_Units_Filters {
 		$stock = $product->get_stock_quantity();
 		
 		// Check stock status and if Out try Out of Stock value	
-		if ( strlen( $stock ) != 0 and $stock <= 0 and isset( $values['min_oos'] ) and $values['min_oos'] != '' ) {
+		if ( strlen( $stock ) !== 0 and $stock <= 0 and isset( $values['min_oos'] ) and !empty($values['min_oos']) ) {
 			$args['min_value'] = $values['min_oos'];
 			
 		// Otherwise just check normal min	
-		} elseif ( $values['min_value'] != ''  ) {
+		} elseif ( !empty($values['min_value'])  ) {
 			$args['min_value'] 	 = $values['min_value'];
 		
 		// If no min, try step	
-		} elseif ( $values['min_value'] == '' and $values['step'] != '' ) {
+		} elseif ( empty($values['min_value']) and !empty($values['step']) ) {
 			$args['min_value'] 	 = $values['step'];
 		} 
 		
 		// Check stock status and if Out try Out of Stock value	
-		if ( $stock <= 0 and isset( $values['min_oos'] ) and $values['max_oos'] != '' ) {
+		if ( $stock <= 0 and isset( $values['min_oos'] ) and !empty($values['max_oos']) ) {
 			$args['max_value'] = $values['max_oos'];
 		
 		// Otherwise just check normal max	
-		} elseif ($values['max_value'] != ''  ) {
+		} elseif (!empty($values['max_value'])  ) {
 			$args['max_value'] 	 = $values['max_value'];
 		}
 		
 		// Set step value
-		if ( $values['step'] != '' ) {
+		if ( !empty($values['step']) ) {
 			$args['step'] = $values['step'];
 		}
 		

--- a/includes/class-wcqu-post-type.php
+++ b/includes/class-wcqu-post-type.php
@@ -115,7 +115,7 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 		        
 		    case 'cats':
 		   		$cats = get_post_meta( $id, '_cats', false);
-		   		if ( $cats != false and count( $cats[0] ) > 0 ) {	   		
+		   		if ( !empty($cats) and count( $cats[0] ) > 0 ) {	   		
 			   		foreach ( $cats[0] as $cat ){
 		
 			   			$taxonomy = 'product_cat'; 	
@@ -129,7 +129,7 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 		        
 		    case 'product_tags':
 		    	$tags = get_post_meta( $id, '_tags', false);
-		   		if ( $tags != null and count( $tags[0] ) > 0) {	   		
+		   		if ( !empty($tags) and count( $tags[0] ) > 0) {	   		
 			   		foreach ( $tags[0] as $tag ){
 		
 			   			$taxonomy = 'product_tag'; 	
@@ -143,7 +143,7 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 		    
 		    case 'roles':
 		   		$roles = get_post_meta( $id, '_roles', false);
-		   		if ( $roles != null and count( $roles[0] ) > 0) {	   		
+		   		if ( !empty($roles) and count( $roles[0] ) > 0) {	   		
 			   		foreach ( $roles[0] as $role ){
 			   			echo ucfirst( $role ) . "<br />";	
 			   		}
@@ -238,7 +238,7 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 		// Get selected categories
 		$cats = get_post_meta( $post->ID, '_cats', false);
 	
-		if ( $cats != null ) {
+		if ( !empty($cats) ) {
 			$cats = $cats[0];
 		}
 		
@@ -287,7 +287,7 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 			foreach ( $children as $child_id ){
 				$child = get_term_by( 'id', $child_id, $taxonomy_name );
 				// If the child is at the second level relative to the last printed element, exclude it
-				if ( is_object( $child ) and $child->parent == $term->term_id ) {
+				if ( is_object( $child ) and (int) $child->parent === (int) $term->term_id ) {
 					$this->print_tax_inputs( $child, $taxonomy_name, $cats, $level );
 				}
 			}
@@ -322,7 +322,7 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 		$tags = get_terms( 'product_tag', $args );
 		
 		$included_tags = get_post_meta( $post->ID, '_tags');
-		if ( $included_tags != false ){
+		if ( !empty($included_tags) ){
 			$included_tags = $included_tags[0];
 		}
 
@@ -367,7 +367,7 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 		
 		// Get applied roles
 		$applied_roles = get_post_meta( $post->ID, '_roles' );
-		if ( $applied_roles != false ){
+		if ( !empty($applied_roles) ){
 			$applied_roles = $applied_roles[0];
 		}
 		// Create Nonce Field
@@ -525,7 +525,7 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 			$max = $_POST['max'];
 			
 			// Validate Max is not less then Min
-			if ( isset( $min ) and $max < $min and $max != 0 ) {
+			if ( isset( $min ) and $max < $min and !empty($max) ) {
 				$max = $min;
 			}
 			
@@ -537,11 +537,11 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 			$max_oos = $_POST['max_oos'];
 				
 			// Max must be bigger then min
-			if ( $max_oos != '' and isset( $min_oos ) and $min_oos != 0 ) {
+			if ( !empty($max_oos) and !empty($min_oos) ) {
 				if ( $min_oos > $max_oos )
 					$max_oos = $min_oos;
 				
-			} elseif ( $max_oos != '' and isset( $min ) and $min != 0 ){
+			} elseif ( !empty($max_oos) and !empty($min) ){
 				if ( $min > $max_oos ) {
 					$max_oos = $min;
 				}
@@ -591,7 +591,7 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 		// See which terms were included
 		foreach ( $terms as $term ) {
 			$term_name = '_wpbo_cat_' . $term->term_id;
-			if ( isset( $_POST[ $term_name ] ) and $_POST[ $term_name ] == 'on' ) {
+			if ( isset( $_POST[ $term_name ] ) and $_POST[ $term_name ] === 'on' ) {
 				array_push( $cats, $term->term_id );		
 			} 
 		}
@@ -637,7 +637,7 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 			foreach ( $tags as $tag ) {
 				
 				$tag_name = '_wpbo_tag_' . $tag->term_id;
-				if ( isset( $_POST[ $tag_name ] ) and $_POST[ $tag_name ] == 'on' ) {
+				if ( isset( $_POST[ $tag_name ] ) and $_POST[ $tag_name ] === 'on' ) {
 					array_push( $tags_included, $tag->term_id );		
 				} 
 			}
@@ -678,13 +678,13 @@ class WC_Quantities_and_Units_Quantity_Rule_Post_Type {
 			$role_name = '_wpbo_role_' . $slug;
 			
 			// If role is set add it to the applied list
-			if ( isset( $_POST[ $role_name ] ) and $_POST[ $role_name ] == 'on' ) {
+			if ( isset( $_POST[ $role_name ] ) and $_POST[ $role_name ] === 'on' ) {
 				array_push( $applied_roles, $slug );
 			}
 		}
 		
 		// If guest role is set add it to the applied list
-		if ( isset( $_POST[ '_wpbo_role_guest' ] ) and $_POST[ '_wpbo_role_guest' ] == 'on' ) {
+		if ( isset( $_POST[ '_wpbo_role_guest' ] ) and $_POST[ '_wpbo_role_guest' ] === 'on' ) {
 			array_push( $applied_roles, 'guest' );
 		}
 

--- a/includes/class-wcqu-product-meta-box.php
+++ b/includes/class-wcqu-product-meta-box.php
@@ -17,7 +17,7 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 	public function meta_box_create() {
 		global $post, $woocommerce;
 
-		if ( $post->post_type == 'product' ) {
+		if ( $post->post_type === 'product' ) {
 			
 			$product = get_product( $post->ID );
 			$unsupported_product_types = array( 'external', 'grouped' );
@@ -62,20 +62,20 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 			// be used later below in the if statements
 			$rule = $newRule ? $newRule : $rule;
 
-			if ( $newRule == 'inactive' or $newRule == 'override' or $newRule == 'sitewide' )
+			if ( $newRule === 'inactive' or $newRule === 'override' or $newRule === 'sitewide' )
 				continue;
 				
 			$rules_by_role[$name] = $newRule;
 		}
 		
 		// Display Rule Being Applied
-		if ( $rule == 'inactive' ) {
+		if ( $rule === 'inactive' ) {
 			echo "<div class='inactive-rule rule-message'>No rule is being applied becasue you've deactivated the plugin for this product.</div>";
 			
-		} elseif ( $rule == 'override' ) {
+		} elseif ( $rule === 'override' ) {
 			echo "<div class='overide-rule rule-message'>The values below are being used because you've chosen to override any applied rules for this product.</div>";
 		
-		} elseif ( $rule == 'sitewide' ) {
+		} elseif ( $rule === 'sitewide' ) {
 			?>
 			<?php $values = wcqu_get_value_from_rule( 'all', $pro, $rule ); ?>
 			<div class="active-rule">
@@ -111,7 +111,7 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 				</table>
 			</div>
 			<?php 
-		} elseif ( (! isset( $rule->post_title ) or $rule->post_title == null) ) {
+		} elseif ( (! isset( $rule->post_title ) or empty($rule->post_title)) ) {
 			echo "<div class='no-rule rule-message'>No rule is currently being applied to this product.</div>";
 			
 		} else { ?>
@@ -139,12 +139,12 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 						<th>Priority</th>
 					</tr>
 				<?php foreach ( $rules_by_role as $role => $rule ): ?>
-					<?php if ( $rule != null )
+					<?php if ( !empty($rule) )
 						$values = wcqu_get_value_from_rule( 'all', $pro, $rule ); 
 					?>
 					<tr>
 						<td><?php echo $role ?></td>
-						<?php if ( $rule != null ): ?>
+						<?php if ( !empty($rule) ): ?>
 							<td><a href='<?php echo get_edit_post_link( $rule->ID ) ?>' target="_blank"><?php echo $rule->post_title ?></a></td>
 							<td><?php echo $values['min_value'] ?></td>
 							<td><?php echo $values['max_value'] ?></td>
@@ -182,13 +182,13 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 		
 		// Print the form ?>	
 		<div class="rule-input-boxes">
-			<input type="checkbox" name="_wpbo_deactive" <?php if ( $deactive == 'on' ) echo 'checked'; ?> />
+			<input type="checkbox" name="_wpbo_deactive" <?php if ( $deactive === 'on' ) echo 'checked'; ?> />
 			<span>Deactivate Quantity Rules on this Product?</span>
 			
-			<input type="checkbox" name="_wpbo_override" id='toggle_override' <?php if ( $over == 'on' ) echo 'checked'; ?> />
+			<input type="checkbox" name="_wpbo_override" id='toggle_override' <?php if ( $over === 'on' ) echo 'checked'; ?> />
 			<span>Override Quantity Rules with Values Below</span>
 			
-			<span class='wpbo_product_values' <?php if ( $over != 'on' ) echo "style='display:none'"?>>
+			<span class='wpbo_product_values' <?php if ( $over !== 'on' ) echo "style='display:none'"?>>
 				<label for="_wpbo_step">Step Value</label>
 				<input type="number" name="_wpbo_step" value="<?php echo $step; ?>" step="any" />
 				
@@ -287,7 +287,7 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 		}
 		
 		if( isset( $_POST['_wpbo_minimum'] )) {
-			if ( $min != 0 ) {
+			if ( !empty($min) ) {
 				$min = wcqu_validate_number( $min );
 			}
 			update_post_meta( 
@@ -300,7 +300,7 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 		/* Make sure Max > Min */
 		if( isset( $_POST['_wpbo_maximum'] )) {
 			$max = $_POST['_wpbo_maximum'];
-			if ( isset( $min ) and $max < $min and $max != 0 ) {
+			if ( isset( $min ) and $max < $min and !empty($max) ) {
 				$max = $min;
 			}
 		
@@ -315,7 +315,7 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 		if( isset( $_POST['_wpbo_minimum_oos'] )) {
 			$min_oos = stripslashes( $_POST['_wpbo_minimum_oos'] );
 			
-			if ( $min_oos != 0 ) {
+			if ( !empty($min_oos) ) {
 				$min_oos = wcqu_validate_number( $min_oos );
 			}
 			update_post_meta( 
@@ -331,19 +331,19 @@ class WC_Quantities_and_Units_Quantity_Meta_Boxes {
 			$max_oos = stripslashes( $_POST['_wpbo_maximum_oos'] );
 			
 			// Allow the value to be unset
-			if ( $max_oos != '' ) {
+			if ( !empty($max_oos) ) {
 				
 				// Validate the number			
-				if ( $max_oos != 0 ) {
+				if ( !empty($max_oos) ) {
 					$max_oos = wcqu_validate_number( $max_oos );
 				} 
 				
 				// Max must be bigger then min
-				if ( isset( $min_oos ) and $min_oos != 0 ) {
+				if ( isset( $min_oos ) and !empty($min_oos) ) {
 					if ( $min_oos > $max_oos )
 						$max_oos = $min_oos;
 					
-				} elseif ( isset( $min ) and $min != 0 ){
+				} elseif ( isset( $min ) and !empty($min) ){
 					if ( $min > $max_oos ) {
 						$max_oos = $min;
 					}

--- a/includes/class-wcqu-validations.php
+++ b/includes/class-wcqu-validations.php
@@ -73,29 +73,29 @@ class WC_Quantities_and_Units_Quantity_Validations {
 		$rule = wcqu_get_applied_rule( $product );
 		$values = wcqu_get_value_from_rule( 'all', $product, $rule );
 		
-		if ( $values != null )
+		if ( !empty($values) )
 			extract( $values ); // $min_value, $max_value, $step, $priority, $min_oos, $max_oos
 				
 		// Inactive Products can be ignored
-		if ( $values == null )
+		if ( empty($values) )
 			return true;
 	
 		// Check if the product is out of stock 
 		$stock = $product->get_stock_quantity();
 	
 		// Adjust min value if item is out of stock
-		if ( strlen( $stock ) != 0 and $stock <= 0 and isset( $min_oos ) and $min_oos != null  ) {
+		if ( strlen( $stock ) !== 0 and $stock <= 0 and isset( $min_oos ) and !empty($min_oos)  ) {
 			$min_value = $min_oos;
 		}
 		
 		// Adjust max value if item is out of stock
-		if ( strlen( $stock ) != 0 and $stock <= 0 and isset( $max_oos ) and $max_oos != null ) {
+		if ( strlen( $stock ) !== 0 and $stock <= 0 and isset( $max_oos ) and !empty($max_oos) ) {
 			$max_value = $max_oos;
 		}
 		
 		// Min Validation
 		// added $min_value != 0 since List Items starts all products at 0 quantity.
-		if ( $min_value != null && $min_value != 0 && $quantity < $min_value ) {
+		if ( !empty($min_value) && $quantity < $min_value ) {
 			
 			if ( $WC_Quantities_and_Units->wc_version >= 2.1 ) {
 				wc_add_notice( sprintf( __( "You must add a minimum of %s %s's to your cart.", 'woocommerce' ), $min_value, $title ), 'error' );
@@ -109,7 +109,7 @@ class WC_Quantities_and_Units_Quantity_Validations {
 		}
 	
 		// Max Validation
-		if ( $max_value != null && $quantity > $max_value ) {
+		if ( !empty($max_value) && $quantity > $max_value ) {
 			
 			if ( $WC_Quantities_and_Units->wc_version >= 2.1 ) {
 				wc_add_notice( sprintf( __( "You may only add a maximum of %s %s's to your cart.", 'woocommerce' ), $max_value, $title ), 'error' );
@@ -122,7 +122,7 @@ class WC_Quantities_and_Units_Quantity_Validations {
 		}
 		
 		// Subtract the min value from quantity to calc remainder if min value exists
-		if ( $min_value != 0 ) {
+		if ( !empty($min_value) ) {
 			$rem_qty = $quantity - $min_value;
 		} else {
 			$rem_qty = $quantity;
@@ -132,7 +132,7 @@ class WC_Quantities_and_Units_Quantity_Validations {
 		$step = (float)$step;
 		
 		// Step Validation	
-		if ( $step != null && wcqu_fmod_round($rem_qty, $step) != 0 ) {
+		if ( !empty($step) && !empty(wcqu_fmod_round($rem_qty, $step)) ) {
 		
 			if ( $WC_Quantities_and_Units->wc_version >= 2.1 ) {
 				wc_add_notice( sprintf( __( "You may only add a %s in multiples of %s to your cart.", 'woocommerce' ), $title, $step ), 'error' );
@@ -146,21 +146,21 @@ class WC_Quantities_and_Units_Quantity_Validations {
 		}
 		
 		// Don't run Cart Validations if user is updating the cart
-		if ( $from_cart != true ) {
+		if ( $from_cart !== true ) {
 		
 			// Get Cart Quantity for the product
 			foreach( $woocommerce->cart->get_cart() as $cart_item_key => $values ) {
 				$_product = $values['data'];
-				if( $product_id == $_product->id ) {
+				if( (int) $product_id === (int) $_product->id ) {
 					$cart_qty = $values['quantity'];
 				}
 			}
 			
 			//  If there aren't any items in the cart already, ignore these validations
-			if ( isset( $cart_qty ) and $cart_qty != null ) {
+			if ( isset( $cart_qty ) and !empty($cart_qty) ) {
 			
 				// Total Cart Quantity Min Validation
-				if ( $min_value != null && ( $quantity + $cart_qty ) < $min_value ) {
+				if ( !empty($min_value) && ( $quantity + $cart_qty ) < $min_value ) {
 					
 					if ( $WC_Quantities_and_Units->wc_version >= 2.1 ) {
 						wc_add_notice( sprintf( __( "Your cart must have a minimum of %s %s's to proceed.", 'woocommerce' ), $min_value, $title ), 'error' );
@@ -173,7 +173,7 @@ class WC_Quantities_and_Units_Quantity_Validations {
 				}
 			
 				// Total Cart Quantity Max Validation
-				if ( $max_value != null && ( $quantity + $cart_qty ) > $max_value ) {
+				if ( !empty($max_value) && ( $quantity + $cart_qty ) > $max_value ) {
 					
 					if ( $WC_Quantities_and_Units->wc_version >= 2.1 ) {
 						wc_add_notice( sprintf( __( "You can only purchase a maximum of %s %s's at once and your cart has %s %s's in it already.", 'woocommerce' ), $max_value, $title, $cart_qty, $title ), 'error' );
@@ -186,7 +186,7 @@ class WC_Quantities_and_Units_Quantity_Validations {
 				}
 				
 				// Subtract the min value from cart quantity to calc remainder if min value exists
-				if ( $min_value != 0 ) {
+				if ( !empty($min_value) ) {
 					$cart_qty_rem = $quantity + $cart_qty - $min_value;
 				} else {
 					$cart_qty_rem = $quantity + $cart_qty;
@@ -194,7 +194,7 @@ class WC_Quantities_and_Units_Quantity_Validations {
 				
 				// Total Cart Quantity Step Validation
 				$cart_qty_rem = (float)$cart_qty_rem;
-				if ( $step != null && $step != 0 && $cart_qty_rem != 0 && wcqu_fmod_round($cart_qty_rem, $step) != 0 ) {
+				if ( !empty($step) && !empty($cart_qty_rem) && !empty(wcqu_fmod_round($cart_qty_rem, $step)) ) {
 					if ( $WC_Quantities_and_Units->wc_version >= 2.1 ) {
 						wc_add_notice( sprintf( __("You may only purchase %s in multiples of %s.", 'woocommerce' ), $title, $step ), 'error' );
 					

--- a/includes/wcqu-functions.php
+++ b/includes/wcqu-functions.php
@@ -13,13 +13,13 @@ function wcqu_get_applied_rule( $product, $role = null ) {
 	// Check for site wide rule
 	$options = get_option( 'ipq_options' );
 	
-	if ( get_post_meta( $product->id, '_wpbo_deactive', true ) == 'on' ) {
+	if ( get_post_meta( $product->id, '_wpbo_deactive', true ) === 'on' ) {
 		return 'inactive';
 		
-	} elseif ( get_post_meta( $product->id, '_wpbo_override', true ) == 'on' ) {
+	} elseif ( get_post_meta( $product->id, '_wpbo_override', true ) === 'on' ) {
 		return 'override';
 	
-	} elseif ( isset( $options['ipq_site_rule_active'] ) and $options['ipq_site_rule_active'] == 'on' ) {
+	} elseif ( isset( $options['ipq_site_rule_active'] ) and $options['ipq_site_rule_active'] === 'on' ) {
 		return 'sitewide';
 		
 	} else {
@@ -44,7 +44,7 @@ function wcqu_get_applied_rule_obj( $product, $role = null ) {
 	// Get role if not passed
 	if(!is_user_logged_in()) {
 		$role = 'guest';
-	} else if ( $role == NULL ) {
+	} else if ( $role === NULL ) {
 		$user_data = get_userdata( get_current_user_id() );
 		if ( $user_data->roles ) {
 			foreach ( $user_data->roles as $cap => $val ) {
@@ -102,13 +102,13 @@ function wcqu_get_applied_rule_obj( $product, $role = null ) {
 	 	$tags = get_post_meta( $rule->ID, '_tags' );
 	 	$roles = get_post_meta( $rule->ID, '_roles' );
 	 		 	
-	 	if( $cats != false )
+	 	if( !empty($cats) )
 		 	$cats = $cats[0];
 	 	
-	 	if( $tags != false )
+	 	if( !empty($tags) )
 		 	$tags = $tags[0];
 
-		if ( $roles != false )
+		if ( !empty($roles) )
 		 	$roles = $roles[0];
 
 	 	$rule_taxes = array_merge( $tags, $cats );
@@ -122,11 +122,11 @@ function wcqu_get_applied_rule_obj( $product, $role = null ) {
 	 	}
 	 	
 	 	// If the rule applies, check the priority
-	 	if ( $apply_rule == true ) {
+	 	if ( $apply_rule === true ) {
 	 	
 	 		$priority = get_post_meta( $rule->ID, '_priority', true );	
 
-	 		if( $priority != '' and $top > $priority or $top == null ) {
+	 		if( !empty($priority) and $top > $priority or $top === null ) {
 	 			$top = $priority;
 	 			$top_rule = $rule;
 		 	}
@@ -147,45 +147,45 @@ function wcqu_get_applied_rule_obj( $product, $role = null ) {
 function wcqu_get_value_from_rule( $type, $product, $rule ) {
 
 	// Validate $type
-	if ( $type != 'min' and 
-		 $type != 'max' and 
-		 $type != 'step' and 
-		 $type != 'all' and 
-		 $type != 'priority' and 
-		 $type != 'role' and
-		 $type != 'min_oos' and
-		 $type != 'max_oos'
+	if ( $type !== 'min' and 
+		 $type !== 'max' and 
+		 $type !== 'step' and 
+		 $type !== 'all' and 
+		 $type !== 'priority' and 
+		 $type !== 'role' and
+		 $type !== 'min_oos' and
+		 $type !== 'max_oos'
 		) {
 		return null;
 	
 	// Validate for missing rule	
-	} elseif ( $rule == null ) {
+	} elseif ( $rule === null ) {
 		return null;
 	
 	// Return Null if Inactive
-	} elseif ( $rule == 'inactive' ) {
+	} elseif ( $rule === 'inactive' ) {
 		return null;
 	
 	// Return Product Meta if Override is on
-	} elseif ( $rule == 'override' ) {
+	} elseif ( $rule === 'override' ) {
 		
 		// Check if the product is out of stock
 		$stock = $product->get_stock_quantity();
 
 		// Check if the product is under stock management and out of stock
-		if ( strlen( $stock ) != 0 and $stock <= 0 ) {
+		if ( strlen( $stock ) !== 0 and $stock <= 0 ) {
 			
 			// Return Out of Stock values if they exist
 			switch ( $type ) {
 				case 'min':
 					$min_oos = get_post_meta( $product->id, '_wpbo_minimum_oos', true );
-					if ( $min_oos != '' )
+					if ( !empty($min_oos) )
 						return $min_oos;
 					break;
 				
 				case 'max':
 					$max_oos = get_post_meta( $product->id, '_wpbo_maximum_oos', true );
-					if ( $max_oos != '' )
+					if ( !empty($max_oos) )
 						return $max_oos;
 					break;	
 			}  
@@ -228,7 +228,7 @@ function wcqu_get_value_from_rule( $type, $product, $rule ) {
 		}		
 	
 	// Check for Site Wide Rule
-	} elseif ( $rule == 'sitewide' ) {
+	} elseif ( $rule === 'sitewide' ) {
 
 		$options = get_option( 'ipq_options' );
 		
@@ -354,7 +354,7 @@ function wcqu_validate_number( $number ) {
 	$number = stripslashes( $number );
 //	$number = intval( $number );
 	
-	if ( $number == 0 ) {
+	if ( empty($number) ) {
 		return null;
 	} elseif ( $number < 0 ) {
 		return null;

--- a/quantites-and-units.php
+++ b/quantites-and-units.php
@@ -95,7 +95,7 @@ class WC_Quantities_and_Units {
 		);
 
 		// If no options set the defaults
-		if ( $options == false ) {
+		if ( $options === false ) {
 			add_option( 'ipq_options', $defaults, '', false );
 		
 		// Otherwise check that all option are set
@@ -145,7 +145,7 @@ class WC_Quantities_and_Units {
 			// If their rule value is false, apply all roles 
 			$roles = get_post_meta( $rule->ID, '_roles', true );
 			
-			if ( $roles == false ) {
+			if ( empty($roles) ) {
 				update_post_meta( $rule->ID, '_roles', $applied_roles, false );
 			}
 		}
@@ -184,7 +184,7 @@ class WC_Quantities_and_Units {
 		global $post, $woocommerce;
 	
 		// Only display script if we are on a single product or cart page
-		if ( is_object( $post ) and $post->post_type == 'product' or is_cart() ) {
+		if ( is_object( $post ) and $post->post_type === 'product' or is_cart() ) {
 			
 			wp_enqueue_script( 
 				'ipq_validation', 
@@ -199,13 +199,13 @@ class WC_Quantities_and_Units {
 				$pro = get_product( $post );
 				
 				// Check if variable
-				if ( $pro->product_type == 'variable' ) {
+				if ( $pro->product_type === 'variable' ) {
 
 					// See what rules are being applied
 					$rule_result = wcqu_get_applied_rule( $pro );
 				
 					// If the rule result is inactive, we're done
-					if ( $rule_result == 'inactive' or $rule_result == null ) {
+					if ( $rule_result === 'inactive' or $rule_result === null ) {
 						return;
 					
 					// Get values for Override, Sitewide and Rule Controlled Products
@@ -217,13 +217,13 @@ class WC_Quantities_and_Units {
 					$stock = $pro->get_stock_quantity();
 			
 					// Check if the product is under stock management and out of stock
-					if ( strlen( $stock ) != 0 and $stock <= 0 ) {
+					if ( strlen( $stock ) !== 0 and $stock <= 0 ) {
 						
-						if ( $values['min_oos'] != '' ) {
+						if ( !empty($values['min_oos']) ) {
 							$values['min_value'] = $values['min_oos'];
 						}
 						
-						if ( $values['max_oos'] != '' ) {
+						if ( !empty($values['max_oos']) ) {
 							$values['max_value'] = $values['max_oos'];
 						}
 						
@@ -320,7 +320,7 @@ class WC_Quantities_and_Units {
 		global $current_user;
 		$user_id = $current_user->ID;
 		
-		if ( isset($_GET['wpbo_thumbnail_plugin_dismiss']) && '0' == $_GET['wpbo_thumbnail_plugin_dismiss'] ) {
+		if ( isset($_GET['wpbo_thumbnail_plugin_dismiss']) && '0' === $_GET['wpbo_thumbnail_plugin_dismiss'] ) {
 			add_user_meta($user_id, 'wpbo_thumbnail_input_notice', 'true', true);
 		}
 	}


### PR DESCRIPTION
Hi Nick,

> [!IMPORTANT]
>**_I noticed that the plugin hasn’t been maintained for a few years. Can you imagine handing over the plugin to another developer? I would be interested._** 😉 **_Please let me know what you think about it._** 🙏🙂

This pull request updates the comparison operators, as PHP8 changed their interpretation and this caused problems.

**Example:**
PHP7: `"" == 0` results in `TRUE`
PHP8: `"" == 0` results in `FALSE`

To solve this, I frequently used the empty() function to restore the old behavior as best as possible.

Best regards,
Helmut